### PR TITLE
Better handle server errors

### DIFF
--- a/example.go
+++ b/example.go
@@ -133,7 +133,8 @@ func main() {
 			if err != nil {
 				fmt.Println("failed to make text request: " + err.Error())
 				fmt.Println(serverResponse)
-				os.Exit(1)
+				fmt.Println("Enter another text query:")
+				continue
 			}
 			writtenResponse, err := houndify.ParseWrittenResponse(serverResponse)
 			if err != nil {

--- a/houndify/houndify_client.go
+++ b/houndify/houndify_client.go
@@ -162,6 +162,10 @@ func (c *Client) TextSearch(textReq TextRequest) (string, error) {
 		fmt.Println(bodyStr)
 	}
 
+	//don't try to parse out conversation state from a bad response
+	if resp.StatusCode >= 400 {
+		return bodyStr, errors.New("error response")
+	}
 	// update with new conversation state
 	if c.enableConversationState {
 		newConvState, err := parseConversationState(bodyStr)


### PR DESCRIPTION
Example app stdin mode continues after an error
Don't attempt to parse results from a 400 or 500 server response