### PR TITLE
improve parsing safety and add vad responses to partial transcripts

### DIFF
--- a/houndify/houndify_client.go
+++ b/houndify/houndify_client.go
@@ -67,6 +67,7 @@ type (
 		PartialTranscript string `json:"PartialTranscript"`
 		DurationMS        int64  `json:"DurationMS"`
 		Done              bool   `json:"Done"`
+		SafeToStopAudio   *bool  `json:"SafeToStopAudio"`
 	}
 )
 
@@ -290,9 +291,10 @@ func (c *Client) VoiceSearch(voiceReq VoiceRequest, partialTranscriptChan chan P
 			partialChanWait.Add(1)
 			go func() {
 				partialTranscriptChan <- PartialTranscript{
-					Message:  incoming.PartialTranscript,
-					Duration: partialDuration,
-					Done:     incoming.Done,
+					Message:         incoming.PartialTranscript,
+					Duration:        partialDuration,
+					Done:            incoming.Done,
+					SafeToStopAudio: incoming.SafeToStopAudio,
 				}
 				partialChanWait.Done()
 			}()

--- a/houndify/partial_transcript.go
+++ b/houndify/partial_transcript.go
@@ -11,4 +11,6 @@ type PartialTranscript struct {
 	Duration time.Duration
 	// If this is the last partial transcript
 	Done bool
+	// True if the server side VAD triggers
+	SafeToStopAudio *bool
 }

--- a/houndify/server_response.go
+++ b/houndify/server_response.go
@@ -18,31 +18,55 @@ type HoundifyDisambiguation struct {
 	ChoiceData []HoundifyDisambiguationChoice
 }
 
+type HoundifyBuildInfo struct {
+	User        string
+	Date        string
+	Machine     string
+	SVNRevision string
+	SVNBranch   string
+	BuildNumber string
+	King        string
+	Variant     string
+}
+
+type HoundifyDomain struct {
+	Domain         string
+	DomainUniqueId string
+	CreditsUsed    float64
+}
+
 type HoundifyResponseResult struct {
 	CommandKind               string
 	SpokenResponse            string
 	SpokenResponseLong        string
 	WrittenResponse           string
 	WrittenResponseLong       string
-	SpokenResponseSSML        *string   `json:"omitempty"`
-	SpokenResponseSSMLLong    *string   `json:"omitempty"`
-	SmallScreenHTML           *string   `json:"omitempty"`
-	LargeScreenHTML           *string   `json:"omitempty"`
-	UnderstandingConfidence   *float64  `json:"omitempty"`
-	OutputOverrideDiagnostics *[]string `json:"omitempty"`
+	SpokenResponseSSML        *string   `json:"SpokenResponseSSML,omitempty"`
+	SpokenResponseSSMLLong    *string   `json:"SpokenResponseSSMLLong,omitempty"`
+	SmallScreenHTML           *string   `json:"SmallScreenHTML,omitempty"`
+	LargeScreenHTML           *string   `json:"LargeScreenHTML,omitempty"`
+	UnderstandingConfidence   *float64  `json:"UnderstandingConfidence,omitempty"`
+	OutputOverrideDiagnostics *[]string `json:"OutputOverrideDiagnostics,omitempty"`
 	AutoListen                bool
 	ConversationState         interface{}
 }
 
 type HoundifyResponse struct {
-	Format          string
-	FormatVersion   string
-	Status          string
-	NumToReturn     int64
-	AllResults      []HoundifyResponseResult
-	ErrorMessage    *string                 `json:"ErrorMessage,omitempty"`
-	ResultsAreFinal *[]bool                 `json:"ResultsAreFinal,omitempty"`
-	Disambiguation  *HoundifyDisambiguation `json:"Disambiguation,omitempty"`
+	Format            string
+	FormatVersion     string
+	Status            string
+	NumToReturn       int64
+	AllResults        []HoundifyResponseResult
+	ErrorMessage      *string                 `json:"ErrorMessage,omitempty"`
+	ResultsAreFinal   *[]bool                 `json:"ResultsAreFinal,omitempty"`
+	Disambiguation    *HoundifyDisambiguation `json:"Disambiguation,omitempty"`
+	QueryID           *string                 `json:"QueryID,omitempty"`
+	ServerGeneratedId *string                 `json:"ServerGeneratedId,omitempty"`
+	AudioLength       *float64                `json:"AudioLength,omitempty"`
+	RealSpeechTime    *float64                `json:"RealSpeechTime,omitempty"`
+	RealTime          *float64                `json:"RealTime,omitempty"`
+	BuildInfo         HoundifyBuildInfo
+	DomainUsage       []HoundifyDomain
 }
 
 // ParseWrittenResponse will take final server response JSON (as a string)

--- a/houndify/server_response.go
+++ b/houndify/server_response.go
@@ -7,38 +7,115 @@ import (
 	"strings"
 )
 
+type HoundifyDisambiguationChoice struct {
+	Transcription      string
+	ConfidenceScore    float64
+	FixedTranscription string
+}
+
+type HoundifyDisambiguation struct {
+	NumToShow  int64
+	ChoiceData []HoundifyDisambiguationChoice
+}
+
+type HoundifyResponseResult struct {
+	CommandKind               string
+	SpokenResponse            string
+	SpokenResponseLong        string
+	WrittenResponse           string
+	WrittenResponseLong       string
+	SpokenResponseSSML        *string   `json:"omitempty"`
+	SpokenResponseSSMLLong    *string   `json:"omitempty"`
+	SmallScreenHTML           *string   `json:"omitempty"`
+	LargeScreenHTML           *string   `json:"omitempty"`
+	UnderstandingConfidence   *float64  `json:"omitempty"`
+	OutputOverrideDiagnostics *[]string `json:"omitempty"`
+	AutoListen                bool
+	ConversationState         interface{}
+}
+
+type HoundifyResponse struct {
+	Format          string
+	FormatVersion   string
+	Status          string
+	NumToReturn     int64
+	AllResults      []HoundifyResponseResult
+	ErrorMessage    *string                 `json:"ErrorMessage,omitempty"`
+	ResultsAreFinal *[]bool                 `json:"ResultsAreFinal,omitempty"`
+	Disambiguation  *HoundifyDisambiguation `json:"Disambiguation,omitempty"`
+}
+
 // ParseWrittenResponse will take final server response JSON (as a string)
-// and parse out the human readable text to be displayed or spoken the end user.
+// and parse out the human readable text to be displayed to the end user.
 // If the string is invalid JSON, the server had an error, or there was nothing
 // to reply with, an error is returned.
 func ParseWrittenResponse(serverResponseJSON string) (string, error) {
-	result := make(map[string]interface{})
+	result := HoundifyResponse{}
 	err := json.Unmarshal([]byte(serverResponseJSON), &result)
 	if err != nil {
 		fmt.Println(err.Error())
 		return "", errors.New("failed to decode json")
 	}
-	if !strings.EqualFold(result["Status"].(string), "OK") {
-		return "", errors.New(result["ErrorMessage"].(string))
+	if !strings.EqualFold(result.Status, "OK") {
+		return "", errors.New(*result.ErrorMessage)
 	}
-	if result["NumToReturn"].(float64) < 1 {
+	if result.NumToReturn < 1 || len(result.AllResults) < 1 {
 		return "", errors.New("no results to return")
 	}
-	return result["AllResults"].([]interface{})[0].(map[string]interface{})["WrittenResponseLong"].(string), nil
+	return result.AllResults[0].WrittenResponseLong, nil
 }
 
-func parseConversationState(serverResponseJSON string) (interface{}, error) {
-	result := make(map[string]interface{})
+// ParseSpokenResponse will take final server response JSON (as a string)
+// and parse out the human readable text to be spoken to the end user.
+// If the string is invalid JSON, the server had an error, or there was nothing
+// to reply with, an error is returned.
+func ParseSpokenResponse(serverResponseJSON string) (string, error) {
+	result := HoundifyResponse{}
 	err := json.Unmarshal([]byte(serverResponseJSON), &result)
 	if err != nil {
 		fmt.Println(err.Error())
-		return nil, errors.New("failed to decode json")
+		return "", errors.New("failed to decode json")
 	}
-	if !strings.EqualFold(result["Status"].(string), "OK") {
-		return nil, errors.New(result["ErrorMessage"].(string))
+	if !strings.EqualFold(result.Status, "OK") {
+		return "", errors.New(*result.ErrorMessage)
 	}
-	if result["NumToReturn"].(float64) < 1 {
-		return nil, errors.New("no results to return")
+	if result.NumToReturn < 1 || len(result.AllResults) < 1 {
+		return "", errors.New("no results to return")
 	}
-	return result["AllResults"].([]interface{})[0].(map[string]interface{})["ConversationState"], nil
+	return result.AllResults[0].SpokenResponseLong, nil
+}
+
+func ParseFirstHypothesis(serverResponseJSON string) (string, error) {
+	result := HoundifyResponse{}
+	err := json.Unmarshal([]byte(serverResponseJSON), &result)
+	if err != nil {
+		fmt.Println(err.Error())
+		return "", errors.New("failed to decode json")
+	}
+	if !strings.EqualFold(result.Status, "OK") {
+		return "", errors.New(*result.ErrorMessage)
+	}
+	if result.Disambiguation == nil {
+		return "", errors.New("no Disabiguation listed")
+	}
+	if result.Disambiguation.NumToShow < 1 || len(result.Disambiguation.ChoiceData) < 1 {
+		return "", errors.New("no Choices listed")
+	}
+	return result.Disambiguation.ChoiceData[0].Transcription, nil
+}
+
+func parseConversationState(serverResponseJSON string) (interface{}, error) {
+	result := HoundifyResponse{}
+	err := json.Unmarshal([]byte(serverResponseJSON), &result)
+	if err != nil {
+		fmt.Println(err.Error())
+		return "", errors.New("failed to decode json")
+	}
+	if !strings.EqualFold(result.Status, "OK") {
+		return "", errors.New(*result.ErrorMessage)
+	}
+	if result.NumToReturn < 1 || len(result.AllResults) < 1 {
+		return "", errors.New("no results to return")
+	}
+	return result.AllResults[0].ConversationState, nil
 }


### PR DESCRIPTION
I added a json object that can be expanded to include any command specific information. This was done to add safety to the parsing code, since the casting done on the return will panic if the server response doesn't match the current format. The new code checks for all of the preconditions, and shouldn't panic for any reason.

In addition, I needed access to houndify's VAD through the SafeToStopAudio bool in the partial transcripts returns, so I expose that through the SDK