### PR TITLE
Develop

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 
 go:
-  - 1.9
+  - 1.12.x
 
 install:
   - go get ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ env:
 
 install:
   - go get ./...
-  - go get github.com/gordonklaus/ineffassign
-  - go get github.com/client9/misspell/cmd/misspell
-  - go get github.com/alecthomas/gometalinter
-  - gometalinter --install
 
 script:
-  - gometalinter  --disable-all -E vet -E gofmt -E misspell -E ineffassign -E deadcode -E gosimple -E varcheck -E structcheck -E unused --tests --vendor ./...
+  - go build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: go
 go:
   - 1.12.x
 
+env:
+  - GO111MODULE=on
+
 install:
   - go get ./...
   - go get github.com/gordonklaus/ineffassign

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ language: go
 go:
   - 1.12.x
 
+branches:
+  only:
+    - master
+
 env:
   - GO111MODULE=on
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Once you have set your `$GOPATH`, you can use both the Go Houndify SDK and examp
 go get github.com/soundhound/houndify-sdk-go
 ```
 
-The example app will be compiled and available at `$GOPATH/bin/houndify-sdk-go` and the SDK will be ready to import and use.
+The example app will be compiled and available at `$GOPATH/bin/houndify-sdk-go` and the SDK will be ready to import and use.  
 
 ## Example App
 
@@ -62,11 +62,11 @@ Instead of using the `--id` and `--key` flags, you may set the environment varia
 
 ## Using the SDK
 
-To use the SDK, you must import the package
+To use the SDK, you must import the `houndify` package:
 
 ```go
 import (
-    houndify "github.com/soundhound/houndify-sdk-go/houndify"
+    "github.com/soundhound/houndify-sdk-go"
 )
 ```
 

--- a/auth.go
+++ b/auth.go
@@ -1,4 +1,4 @@
-package houndify
+package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
 
 import (
 	"crypto/hmac"

--- a/auth.go
+++ b/auth.go
@@ -1,4 +1,4 @@
-package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
+package houndify
 
 import (
 	"crypto/hmac"

--- a/example/example.go
+++ b/example/example.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"strings"
 
-	houndify "github.com/soundhound/houndify-sdk-go/houndify"
+	houndify "github.com/soundhound/houndify-sdk-go"
 )
 
 const (

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/soundhound/houndify-sdk-go
+
+go 1.12

--- a/houndify/go.mod
+++ b/houndify/go.mod
@@ -1,3 +1,0 @@
-module github.com/soundhound/houndify-sdk-go/houndify
-
-go 1.12

--- a/houndify_client.go
+++ b/houndify_client.go
@@ -35,7 +35,8 @@ type (
 		conversationState       interface{}
 		// If Verbose is true, all data sent from the server is printed to stdout, unformatted and unparsed.
 		// This includes partial transcripts, errors, HTTP headers details (status code, headers, etc.), and final response JSON.
-		Verbose bool
+		Verbose    bool
+		HttpClient *http.Client
 	}
 	// A TextRequest holds all the information needed to make a Houndify request.
 	// Create one of these per request to send and use a Client to send it.
@@ -152,8 +153,10 @@ func (c *Client) TextSearch(textReq TextRequest) (string, error) {
 	}
 	req.Header.Set("Hound-Request-Info", string(requestInfoJSON))
 
-	client := &http.Client{}
-	resp, err := client.Do(req)
+	if c.HttpClient == nil {
+		c.HttpClient = &http.Client{}
+	}
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return "", errors.New("failed to successfully run request: " + err.Error())
 	}
@@ -245,11 +248,14 @@ func (c *Client) VoiceSearch(voiceReq VoiceRequest, partialTranscriptChan chan P
 	req.Header.Set("Hound-Request-Info", string(requestInfoJSON))
 
 	req.Body = ioutil.NopCloser(voiceReq.AudioStream)
-	client := &http.Client{}
+
+	if c.HttpClient == nil {
+		c.HttpClient = &http.Client{}
+	}
 
 	// send the request
 
-	resp, err := client.Do(req)
+	resp, err := c.HttpClient.Do(req)
 	if err != nil {
 		return "", errors.New("failed to successfully run request: " + err.Error())
 	}

--- a/houndify_client.go
+++ b/houndify_client.go
@@ -1,4 +1,4 @@
-package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
+package houndify
 
 import (
 	"bufio"

--- a/houndify_client.go
+++ b/houndify_client.go
@@ -45,6 +45,7 @@ type (
 		UserID            string
 		RequestID         string
 		RequestInfoFields map[string]interface{}
+		URL               string
 	}
 	// A VoiceRequest holds all the information needed to make a Houndify request.
 	// Create one of these per request to send and use a Client to send it.
@@ -55,6 +56,7 @@ type (
 		UserID            string
 		RequestID         string
 		RequestInfoFields map[string]interface{}
+		URL               string
 	}
 
 	// all of the Hound server JSON messages have these basic fields
@@ -102,9 +104,15 @@ func (c *Client) SetConversationState(newState interface{}) {
 // connect, failure to parse the response, or failure to update the conversation
 // state (if applicable).
 func (c *Client) TextSearch(textReq TextRequest) (string, error) {
+
+	// Use set URL, or fallback to default
+	if len(textReq.URL) == 0 {
+		textReq.URL = houndifyTextURL
+	}
+
 	// setup http request
 	body := []byte(``)
-	req, err := http.NewRequest("POST", houndifyTextURL+"?query="+url.PathEscape(textReq.Query), bytes.NewBuffer(body))
+	req, err := http.NewRequest("POST", textReq.URL+"?query="+url.PathEscape(textReq.Query), bytes.NewBuffer(body))
 	if err != nil {
 		return "", errors.New("failed to build http request: " + err.Error())
 	}
@@ -191,8 +199,12 @@ func (c *Client) TextSearch(textReq TextRequest) (string, error) {
 // connect, failure to parse the response, or failure to update the conversation
 // state (if applicable).
 func (c *Client) VoiceSearch(voiceReq VoiceRequest, partialTranscriptChan chan PartialTranscript) (string, error) {
+	if len(voiceReq.URL) == 0 {
+		voiceReq.URL = houndifyVoiceURL
+	}
+
 	// setup http request
-	req, err := http.NewRequest("POST", houndifyVoiceURL, nil)
+	req, err := http.NewRequest("POST", voiceReq.URL, nil)
 	if err != nil {
 		return "", errors.New("failed to build http request: " + err.Error())
 	}

--- a/houndify_client.go
+++ b/houndify_client.go
@@ -1,4 +1,4 @@
-package houndify
+package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
 
 import (
 	"bufio"

--- a/partial_transcript.go
+++ b/partial_transcript.go
@@ -1,4 +1,4 @@
-package houndify
+package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
 
 import (
 	"time"

--- a/partial_transcript.go
+++ b/partial_transcript.go
@@ -1,4 +1,4 @@
-package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
+package houndify
 
 import (
 	"time"

--- a/request_info.go
+++ b/request_info.go
@@ -1,4 +1,4 @@
-package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
+package houndify
 
 type requestInfo map[string]interface{}
 

--- a/request_info.go
+++ b/request_info.go
@@ -1,4 +1,4 @@
-package houndify
+package houndify // import "github.com/soundhound/houndify-sdk-go/houndify"
 
 type requestInfo map[string]interface{}
 

--- a/server_response.go
+++ b/server_response.go
@@ -1,4 +1,4 @@
-package houndify
+package houndify // import github.com/soundhound/houndify-sdk-go/houndify
 
 import (
 	"encoding/json"

--- a/server_response.go
+++ b/server_response.go
@@ -1,4 +1,4 @@
-package houndify // import github.com/soundhound/houndify-sdk-go/houndify
+package houndify
 
 import (
 	"encoding/json"


### PR DESCRIPTION
- Update project structure to remove the sub-package, instead having only a single package `houndify` that is located at `github.com/soundhound/houndify-sdk-go`.
- Added go mod to project to manage dependencies (which don't exist yet)
- Added option to specify a URL for both TextRequests and VoiceRequests
- Added option to provide `http.Client` to `houndify.Client` to modify the request behaviour
- Updated outdated travis build to remove the deprecated linter